### PR TITLE
fix(streamproxy): pipe yt-dlp into ffmpeg for HLS-only YouTube videos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- `sonos play-url` now plays YouTube videos that only expose HLS audio formats (e.g. live/DVR-style or music recordings without progressive `itag 140`). The proxy now pipes `yt-dlp` directly into `ffmpeg` for `yt-dlp` sources, so YouTube's HLS segments are decoded by `yt-dlp`'s `hlsnative` downloader instead of `ffmpeg`'s HLS demuxer (which rejects YouTube's mismatched segment extensions). Thanks @bgrgicak.
+
 ## [0.3.0] - 2026-05-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
-- `sonos play-url` now plays YouTube videos that only expose HLS audio formats (e.g. live/DVR-style or music recordings without progressive `itag 140`). The proxy now pipes `yt-dlp` directly into `ffmpeg` for `yt-dlp` sources, so YouTube's HLS segments are decoded by `yt-dlp`'s `hlsnative` downloader instead of `ffmpeg`'s HLS demuxer (which rejects YouTube's mismatched segment extensions).
+- `sonos play-url` now plays YouTube videos that only expose HLS audio formats (e.g. live/DVR-style or music recordings without progressive `itag 140`). The proxy now pipes `yt-dlp` directly into `ffmpeg` for `yt-dlp` sources, so YouTube's HLS segments are decoded by `yt-dlp`'s `hlsnative` downloader instead of `ffmpeg`'s HLS demuxer (which rejects YouTube's mismatched segment extensions). Thanks @bgrgicak.
 
 ## [0.3.0] - 2026-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
-- `sonos play-url` now plays YouTube videos that only expose HLS audio formats (e.g. live/DVR-style or music recordings without progressive `itag 140`). The proxy now pipes `yt-dlp` directly into `ffmpeg` for `yt-dlp` sources, so YouTube's HLS segments are decoded by `yt-dlp`'s `hlsnative` downloader instead of `ffmpeg`'s HLS demuxer (which rejects YouTube's mismatched segment extensions). Thanks @bgrgicak.
+- `sonos play-url` now plays YouTube videos that only expose HLS audio formats (e.g. live/DVR-style or music recordings without progressive `itag 140`). The proxy now pipes `yt-dlp` directly into `ffmpeg` for `yt-dlp` sources, so YouTube's HLS segments are decoded by `yt-dlp`'s `hlsnative` downloader instead of `ffmpeg`'s HLS demuxer (which rejects YouTube's mismatched segment extensions).
 
 ## [0.3.0] - 2026-05-07
 

--- a/internal/streamproxy/config.go
+++ b/internal/streamproxy/config.go
@@ -12,6 +12,7 @@ const (
 	DefaultAddr        = "127.0.0.1:0"
 	DefaultPath        = "/stream.mp3"
 	DefaultFFmpegPath  = "ffmpeg"
+	DefaultYTDLPPath   = "yt-dlp"
 	DefaultBitrate     = "192k"
 	DefaultIdleTimeout = 20 * time.Second
 	HealthPath         = "/healthz"
@@ -49,6 +50,12 @@ func (cfg ServerConfig) withDefaults() ServerConfig {
 	}
 	if strings.TrimSpace(cfg.FFmpegPath) == "" {
 		cfg.FFmpegPath = DefaultFFmpegPath
+	}
+	if strings.TrimSpace(cfg.YTDLPPath) == "" {
+		cfg.YTDLPPath = DefaultYTDLPPath
+	}
+	if strings.TrimSpace(cfg.Format) == "" {
+		cfg.Format = DefaultFormat
 	}
 	if strings.TrimSpace(cfg.Bitrate) == "" {
 		cfg.Bitrate = DefaultBitrate

--- a/internal/streamproxy/ffmpeg.go
+++ b/internal/streamproxy/ffmpeg.go
@@ -76,20 +76,12 @@ func (s *Server) ffmpegStdinCommand(ctx context.Context) *exec.Cmd {
 }
 
 func (s *Server) ytDLPDownloadCommand(ctx context.Context, sourceURL string) *exec.Cmd {
-	path := strings.TrimSpace(s.cfg.YTDLPPath)
-	if path == "" {
-		path = "yt-dlp"
-	}
-	format := strings.TrimSpace(s.cfg.Format)
-	if format == "" {
-		format = DefaultFormat
-	}
 	//nolint:gosec // yt-dlp path is configured by CLI flag; the source URL was supplied by the user.
-	return exec.CommandContext(ctx, path,
+	return exec.CommandContext(ctx, strings.TrimSpace(s.cfg.YTDLPPath),
 		"--no-playlist",
 		"--no-warnings",
 		"--quiet",
-		"-f", format,
+		"-f", strings.TrimSpace(s.cfg.Format),
 		"-o", "-",
 		sourceURL,
 	)

--- a/internal/streamproxy/ffmpeg.go
+++ b/internal/streamproxy/ffmpeg.go
@@ -58,3 +58,39 @@ func (s *Server) ffmpegCommand(ctx context.Context, streamURL string) *exec.Cmd 
 		"pipe:1",
 	)
 }
+
+func (s *Server) ffmpegStdinCommand(ctx context.Context) *exec.Cmd {
+	//nolint:gosec // ffmpeg path is an explicit CLI option; input is read from stdin.
+	return exec.CommandContext(ctx, strings.TrimSpace(s.cfg.FFmpegPath),
+		"-hide_banner",
+		"-loglevel", "error",
+		"-i", "pipe:0",
+		"-vn",
+		"-ac", "2",
+		"-ar", "44100",
+		"-codec:a", "libmp3lame",
+		"-b:a", s.cfg.Bitrate,
+		"-f", "mp3",
+		"pipe:1",
+	)
+}
+
+func (s *Server) ytDLPDownloadCommand(ctx context.Context, sourceURL string) *exec.Cmd {
+	path := strings.TrimSpace(s.cfg.YTDLPPath)
+	if path == "" {
+		path = "yt-dlp"
+	}
+	format := strings.TrimSpace(s.cfg.Format)
+	if format == "" {
+		format = DefaultFormat
+	}
+	//nolint:gosec // yt-dlp path is configured by CLI flag; the source URL was supplied by the user.
+	return exec.CommandContext(ctx, path,
+		"--no-playlist",
+		"--no-warnings",
+		"--quiet",
+		"-f", format,
+		"-o", "-",
+		sourceURL,
+	)
+}

--- a/internal/streamproxy/server.go
+++ b/internal/streamproxy/server.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/exec"
 	"strings"
 	"sync"
 	"time"
@@ -151,23 +152,60 @@ func (s *Server) handleStream(w http.ResponseWriter, r *http.Request) {
 		s.mu.Unlock()
 	}()
 
-	streamURL, err := s.resolver.ResolveStreamURL(r.Context(), s.cfg.Source)
-	if err != nil {
-		log.Printf("resolve stream URL failed: %v", err)
-		http.Error(w, err.Error(), http.StatusBadGateway)
-		return
-	}
-	log.Printf("client %q requested stream; resolved input=%q", r.RemoteAddr, streamURL) //nolint:gosec // diagnostic log only; values are quoted.
+	useYTDLP := s.cfg.Source.UseYTDLP
 
-	cmd := s.ffmpegCommand(r.Context(), streamURL)
+	var streamURL string
+	if !useYTDLP {
+		var resolveErr error
+		streamURL, resolveErr = s.resolver.ResolveStreamURL(r.Context(), s.cfg.Source)
+		if resolveErr != nil {
+			log.Printf("resolve stream URL failed: %v", resolveErr)
+			http.Error(w, resolveErr.Error(), http.StatusBadGateway)
+			return
+		}
+		log.Printf("client %q requested stream; resolved input=%q", r.RemoteAddr, streamURL) //nolint:gosec // diagnostic log only; values are quoted.
+	} else {
+		log.Printf("client %q requested stream; piping yt-dlp source=%q", r.RemoteAddr, s.cfg.Source.URL) //nolint:gosec // diagnostic log only; values are quoted.
+	}
+
+	var ytCmd *exec.Cmd
+	var cmd *exec.Cmd
+	if useYTDLP {
+		ytCmd = s.ytDLPDownloadCommand(r.Context(), s.cfg.Source.URL)
+		ytStdout, err := ytCmd.StdoutPipe()
+		if err != nil {
+			log.Printf("yt-dlp stdout pipe failed: %v", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		ytCmd.Stderr = os.Stderr
+		if err := ytCmd.Start(); err != nil {
+			log.Printf("yt-dlp start failed: %v", err)
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
+		cmd = s.ffmpegStdinCommand(r.Context())
+		cmd.Stdin = ytStdout
+	} else {
+		cmd = s.ffmpegCommand(r.Context(), streamURL)
+	}
+
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
+		if ytCmd != nil {
+			_ = ytCmd.Process.Kill()
+			_ = ytCmd.Wait()
+		}
 		log.Printf("ffmpeg stdout pipe failed: %v", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {
+		if ytCmd != nil {
+			_ = ytCmd.Process.Kill()
+			_ = ytCmd.Wait()
+		}
 		log.Printf("ffmpeg start failed: %v", err)
 		http.Error(w, err.Error(), http.StatusBadGateway)
 		return
@@ -175,6 +213,10 @@ func (s *Server) handleStream(w http.ResponseWriter, r *http.Request) {
 	defer func() {
 		_ = cmd.Process.Kill()
 		_ = cmd.Wait()
+		if ytCmd != nil && ytCmd.Process != nil {
+			_ = ytCmd.Process.Kill()
+			_ = ytCmd.Wait()
+		}
 	}()
 
 	writer := io.Writer(w)

--- a/internal/streamproxy/server.go
+++ b/internal/streamproxy/server.go
@@ -15,21 +15,19 @@ import (
 )
 
 type Server struct {
-	cfg      ServerConfig
-	resolver Resolver
-	mu       sync.Mutex
-	active   int
-	served   bool
-	done     chan struct{}
-	once     sync.Once
+	cfg    ServerConfig
+	mu     sync.Mutex
+	active int
+	served bool
+	done   chan struct{}
+	once   sync.Once
 }
 
 func NewServer(cfg ServerConfig) *Server {
 	cfg = cfg.withDefaults()
 	return &Server{
-		cfg:      cfg,
-		resolver: Resolver{YTDLPPath: cfg.YTDLPPath, Format: cfg.Format},
-		done:     make(chan struct{}),
+		cfg:  cfg,
+		done: make(chan struct{}),
 	}
 }
 
@@ -73,7 +71,6 @@ func (s *Server) Preflight(ctx context.Context) error {
 		return err
 	}
 	s.cfg = cfg
-	s.resolver = Resolver{YTDLPPath: cfg.YTDLPPath, Format: cfg.Format}
 	return nil
 }
 
@@ -152,25 +149,10 @@ func (s *Server) handleStream(w http.ResponseWriter, r *http.Request) {
 		s.mu.Unlock()
 	}()
 
-	useYTDLP := s.cfg.Source.UseYTDLP
-
-	var streamURL string
-	if !useYTDLP {
-		var resolveErr error
-		streamURL, resolveErr = s.resolver.ResolveStreamURL(r.Context(), s.cfg.Source)
-		if resolveErr != nil {
-			log.Printf("resolve stream URL failed: %v", resolveErr)
-			http.Error(w, resolveErr.Error(), http.StatusBadGateway)
-			return
-		}
-		log.Printf("client %q requested stream; resolved input=%q", r.RemoteAddr, streamURL) //nolint:gosec // diagnostic log only; values are quoted.
-	} else {
-		log.Printf("client %q requested stream; piping yt-dlp source=%q", r.RemoteAddr, s.cfg.Source.URL) //nolint:gosec // diagnostic log only; values are quoted.
-	}
-
 	var ytCmd *exec.Cmd
 	var cmd *exec.Cmd
-	if useYTDLP {
+	if s.cfg.Source.UseYTDLP {
+		log.Printf("client %q requested stream; piping yt-dlp source=%q", r.RemoteAddr, s.cfg.Source.URL) //nolint:gosec // diagnostic log only; values are quoted.
 		ytCmd = s.ytDLPDownloadCommand(r.Context(), s.cfg.Source.URL)
 		ytStdout, err := ytCmd.StdoutPipe()
 		if err != nil {
@@ -187,6 +169,11 @@ func (s *Server) handleStream(w http.ResponseWriter, r *http.Request) {
 		cmd = s.ffmpegStdinCommand(r.Context())
 		cmd.Stdin = ytStdout
 	} else {
+		streamURL := strings.TrimSpace(s.cfg.Source.InputURL)
+		if streamURL == "" {
+			streamURL = strings.TrimSpace(s.cfg.Source.URL)
+		}
+		log.Printf("client %q requested stream; resolved input=%q", r.RemoteAddr, streamURL) //nolint:gosec // diagnostic log only; values are quoted.
 		cmd = s.ffmpegCommand(r.Context(), streamURL)
 	}
 
@@ -213,7 +200,7 @@ func (s *Server) handleStream(w http.ResponseWriter, r *http.Request) {
 	defer func() {
 		_ = cmd.Process.Kill()
 		_ = cmd.Wait()
-		if ytCmd != nil && ytCmd.Process != nil {
+		if ytCmd != nil {
 			_ = ytCmd.Process.Kill()
 			_ = ytCmd.Wait()
 		}

--- a/internal/streamproxy/server_test.go
+++ b/internal/streamproxy/server_test.go
@@ -128,6 +128,29 @@ func TestHandleStreamCopiesFFmpegOutput(t *testing.T) {
 	}
 }
 
+func TestHandleStreamPipesYTDLPThroughFFmpeg(t *testing.T) {
+	t.Parallel()
+
+	ffmpeg := fakeFFmpeg(t, "piped output")
+	ytDLP := fakeYTDLP(t)
+	srv := NewServer(ServerConfig{
+		Source:     Source{URL: "https://example.com/page", UseYTDLP: true},
+		FFmpegPath: ffmpeg,
+		YTDLPPath:  ytDLP,
+	})
+	req := httptest.NewRequest(http.MethodGet, "/stream.mp3", nil)
+	rec := httptest.NewRecorder()
+
+	srv.handleStream(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%q", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if got := strings.TrimSuffix(rec.Body.String(), "\n"); got != "piped output" {
+		t.Fatalf("body = %q, want %q", got, "piped output")
+	}
+}
+
 func TestHandleStreamErrors(t *testing.T) {
 	t.Parallel()
 

--- a/internal/streamproxy/server_test.go
+++ b/internal/streamproxy/server_test.go
@@ -128,10 +128,31 @@ func TestHandleStreamCopiesFFmpegOutput(t *testing.T) {
 	}
 }
 
+func TestHandleStreamFallsBackToSourceURLWhenInputURLEmpty(t *testing.T) {
+	t.Parallel()
+
+	ffmpeg := fakeFFmpeg(t, "url-fallback output")
+	srv := NewServer(ServerConfig{
+		Source:     Source{URL: "https://example.com/episode.mp3"},
+		FFmpegPath: ffmpeg,
+	})
+	req := httptest.NewRequest(http.MethodGet, "/stream.mp3", nil)
+	rec := httptest.NewRecorder()
+
+	srv.handleStream(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%q", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if got := strings.TrimSuffix(rec.Body.String(), "\n"); got != "url-fallback output" {
+		t.Fatalf("body = %q", got)
+	}
+}
+
 func TestHandleStreamPipesYTDLPThroughFFmpeg(t *testing.T) {
 	t.Parallel()
 
-	ffmpeg := fakeFFmpeg(t, "piped output")
+	ffmpeg := fakeFFmpegEchoStdin(t)
 	ytDLP := fakeYTDLP(t)
 	srv := NewServer(ServerConfig{
 		Source:     Source{URL: "https://example.com/page", UseYTDLP: true},
@@ -146,8 +167,10 @@ func TestHandleStreamPipesYTDLPThroughFFmpeg(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d body=%q", rec.Code, http.StatusOK, rec.Body.String())
 	}
-	if got := strings.TrimSuffix(rec.Body.String(), "\n"); got != "piped output" {
-		t.Fatalf("body = %q, want %q", got, "piped output")
+	// fakeYTDLP without -g/-j flags writes its JSON template to stdout; fakeFFmpegEchoStdin
+	// copies stdin to stdout, so the response body must contain that JSON.
+	if !strings.Contains(rec.Body.String(), `"title":"Track Title"`) {
+		t.Fatalf("expected yt-dlp output piped through ffmpeg in body, got %q", rec.Body.String())
 	}
 }
 
@@ -180,6 +203,20 @@ func TestHandleStreamErrors(t *testing.T) {
 	t.Run("ffmpeg", func(t *testing.T) {
 		srv := NewServer(ServerConfig{
 			Source:     Source{URL: "https://example.com/episode.mp3", InputURL: "https://example.com/episode.mp3"},
+			FFmpegPath: filepath.Join(t.TempDir(), "missing-ffmpeg"),
+		})
+		req := httptest.NewRequest(http.MethodGet, "/stream.mp3", nil)
+		rec := httptest.NewRecorder()
+		srv.handleStream(rec, req)
+		if rec.Code != http.StatusBadGateway {
+			t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadGateway)
+		}
+	})
+
+	t.Run("ffmpeg_with_ytdlp_running", func(t *testing.T) {
+		srv := NewServer(ServerConfig{
+			Source:     Source{URL: "https://example.com/page", UseYTDLP: true},
+			YTDLPPath:  fakeYTDLP(t),
 			FFmpegPath: filepath.Join(t.TempDir(), "missing-ffmpeg"),
 		})
 		req := httptest.NewRequest(http.MethodGet, "/stream.mp3", nil)
@@ -310,6 +347,56 @@ func TestServeHealthAndShutdown(t *testing.T) {
 	}
 }
 
+func TestServeHandlesStreamOverHTTP(t *testing.T) {
+	t.Parallel()
+
+	ffmpeg := fakeFFmpeg(t, "served body")
+	port := freeTestTCPPort(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	srv := NewServer(ServerConfig{
+		Addr:        "127.0.0.1:" + port,
+		Path:        "/stream.mp3",
+		Source:      Source{URL: "https://example.com/episode.mp3", InputURL: "https://example.com/episode.mp3", Title: "Episode"},
+		FFmpegPath:  ffmpeg,
+		IdleTimeout: time.Second,
+	})
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.Serve(ctx)
+	}()
+
+	streamURL := "http://127.0.0.1:" + port + "/stream.mp3"
+	deadline := time.Now().Add(2 * time.Second)
+	var body []byte
+	for {
+		resp, err := http.Get(streamURL) //nolint:gosec // local test server URL.
+		if err == nil && resp.StatusCode == http.StatusOK {
+			body, _ = io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			break
+		}
+		if err == nil {
+			_ = resp.Body.Close()
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("could not fetch stream: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := strings.TrimSuffix(string(body), "\n"); got != "served body" {
+		t.Fatalf("body = %q, want %q", got, "served body")
+	}
+
+	cancel()
+	select {
+	case <-errCh:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("server did not stop")
+	}
+}
+
 func TestServeListenError(t *testing.T) {
 	t.Parallel()
 
@@ -424,6 +511,33 @@ type errWriter struct{}
 
 func (errWriter) Write([]byte) (int, error) {
 	return 0, io.ErrClosedPipe
+}
+
+func fakeFFmpegEchoStdin(t *testing.T) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "ffmpeg")
+	script := `#!/bin/sh
+if [ "${1:-}" = "-version" ]; then
+  printf '%s\n' 'ffmpeg version test'
+  exit 0
+fi
+cat
+`
+	if err := os.WriteFile(path, []byte(script), 0o700); err != nil {
+		t.Fatalf("write fake ffmpeg: %v", err)
+	}
+	deadline := time.Now().Add(time.Second)
+	for {
+		if err := exec.Command(path, "-version").Run(); err == nil { //nolint:gosec // test-owned helper script.
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("fake ffmpeg did not become executable")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return path
 }
 
 func fakeFFmpeg(t *testing.T, output string) string {


### PR DESCRIPTION
## Summary

`sonos play-url` now plays YouTube videos that only expose HLS audio formats (`itag 233`/`234`). Previously the proxy ran `yt-dlp -g` and pointed `ffmpeg` at the resolved URL, which fails on these sources because `ffmpeg`'s HLS demuxer rejects YouTube's segments (chunk URLs end in `.ts` but the bytes are raw AAC).

## Motivation

YouTube increasingly serves audio-only via HLS for live/DVR-style uploads, KEXP-style recordings, and many videos surfaced through YouTube Music — `yt-dlp -F` lists only `m3u8` formats. The user-visible symptom: `play-url` returns success, the speaker accepts the URI, and `status` stays `STOPPED`. Format-selector tweaks and `-allowed_extensions ALL` don't help because there's no progressive m4a to fall back to.

## Implementation

For sources where `Source.UseYTDLP` is true, `handleStream` now spawns a pipeline:

```
yt-dlp -f <format> -o - <url>  →  ffmpeg -i pipe:0 ... -f mp3 pipe:1  →  client
```

`yt-dlp`'s `hlsnative` downloader handles the m3u8 → AAC-segment fetch, so `ffmpeg` only sees a clean byte stream. The direct (non-`yt-dlp`) URL path is unchanged — podcasts, direct audio, and radio still go straight to `ffmpeg -i <url>`. The deferred cleanup also kills the `yt-dlp` child so the proxy's idle/EOF shutdown still works.

## Out of scope

Whole YouTube playlist URLs (`?list=...` with no `?v=`) still don't play — `yt-dlp -j` emits one JSON object per item and the resolver only reads one. Playlist support would mean enumerating items and calling the queue-and-play helper #14 added; separate feature.

## Testing instructions

### Automated

```bash
go test ./...
golangci-lint run ./...
```

New `TestHandleStreamPipesYTDLPThroughFFmpeg` wires a fake `yt-dlp` into a fake `ffmpeg` through `handleStream`. Existing `TestHandleStreamErrors/resolve` still asserts missing `yt-dlp` returns 502.

### Manual — live-verified

1. Pick a YouTube URL whose `yt-dlp -F` shows only `m3u8` audio formats. Reliable repros: `https://www.youtube.com/watch?v=XvKkIttJLcc` (Queen — Live Aid) and `https://www.youtube.com/watch?v=WhOmCYmEkvU` (Sleaford Mods — KEXP).
2. `./bin/sonos play-url --name "<Room>" "<URL>"`, then `./bin/sonos status --name "<Room>"`. Pre-fix: `State: STOPPED`. Post-fix: `State: PLAYING`, `Time` advancing.
3. Regression: a direct `.mp3` URL and a YouTube video with `itag 140` both still play.