### PR TITLE
Add support for intel macs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
           {
             echo "RELEASE_TAG=${release_tag}"
             echo "RELEASE_VERSION=${release_version}"
-            echo "MACOS_ARTIFACT=sonoscli_${release_version}_darwin_arm64.tar.gz"
+            echo "ARTIFACT_TEMPLATE=sonoscli_${release_version}_{target}.tar.gz"
           } >> "${GITHUB_ENV}"
 
       - name: Dispatch tap formula update
@@ -81,7 +81,7 @@ jobs:
             -f formula=sonoscli \
             -f tag="${RELEASE_TAG}" \
             -f repository=steipete/sonoscli \
-            -f macos_artifact="${MACOS_ARTIFACT}" \
+            -f artifact_template="${ARTIFACT_TEMPLATE}" \
             -f request_id="${request_id}"
 
           run_id=""

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
           {
             echo "RELEASE_TAG=${release_tag}"
             echo "RELEASE_VERSION=${release_version}"
-            echo "ARTIFACT_TEMPLATE=sonoscli_${release_version}_{target}.tar.gz"
+            echo "MACOS_ARTIFACT=sonoscli_${release_version}_macos-universal.tar.gz"
           } >> "${GITHUB_ENV}"
 
       - name: Dispatch tap formula update
@@ -81,7 +81,7 @@ jobs:
             -f formula=sonoscli \
             -f tag="${RELEASE_TAG}" \
             -f repository=steipete/sonoscli \
-            -f artifact_template="${ARTIFACT_TEMPLATE}" \
+            -f macos_artifact="${MACOS_ARTIFACT}" \
             -f request_id="${request_id}"
 
           run_id=""

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,11 +19,18 @@ builds:
       - windows_amd64
       - windows_arm64
 
+universal_binaries:
+  - id: sonos
+    ids:
+      - sonos
+    name_template: sonos
+    replace: true
+
 archives:
   - builds:
       - sonos
     format: tar.gz
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ if eq .Os "darwin" }}macos-universal{{ else }}{{ .Os }}_{{ .Arch }}{{ end }}'
     format_overrides:
       - goos: windows
         format: zip

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,16 +24,18 @@ universal_binaries:
     ids:
       - sonos
     name_template: sonos
-    replace: true
+    replace: false
 
 archives:
-  - builds:
+  - ids:
       - sonos
-    format: tar.gz
-    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ if eq .Os "darwin" }}macos-universal{{ else }}{{ .Os }}_{{ .Arch }}{{ end }}'
+    formats:
+      - tar.gz
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ if and (eq .Os "darwin") (eq .Arch "all") }}macos-universal{{ else }}{{ .Os }}_{{ .Arch }}{{ end }}'
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
 
 checksum:
   name_template: checksums.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Docker: add a local image with bundled `ffmpeg`, `yt-dlp`, and CI smoke coverage.
+- Release archives now include a macOS universal binary while preserving the legacy `darwin_amd64` and `darwin_arm64` asset names. Thanks @streeter.
 
 ## [0.3.1] - 2026-05-10
 

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,11 @@ build:
 
 build-darwin:
 	mkdir -p bin
-	GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -o bin/sonos-darwin-amd64 ./cmd/sonos
-	GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -o bin/sonos-darwin-arm64 ./cmd/sonos
+	tmp="$$(mktemp -d)"; \
+	trap 'rm -rf "$$tmp"' EXIT; \
+	GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -o "$$tmp/sonos-darwin-amd64" ./cmd/sonos; \
+	GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -o "$$tmp/sonos-darwin-arm64" ./cmd/sonos; \
+	lipo -create -output bin/sonos-darwin-universal "$$tmp/sonos-darwin-amd64" "$$tmp/sonos-darwin-arm64"
 
 lint:
 	golangci-lint run ./...

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: fmt fmt-check lint test race coverage build ci docs-site
+.PHONY: fmt fmt-check lint test race coverage build build-darwin ci docs-site
 
 fmt:
 	gofmt -w .
@@ -25,6 +25,11 @@ coverage:
 build:
 	mkdir -p bin
 	go build -o bin/sonos ./cmd/sonos
+
+build-darwin:
+	mkdir -p bin
+	GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -o bin/sonos-darwin-amd64 ./cmd/sonos
+	GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -o bin/sonos-darwin-arm64 ./cmd/sonos
 
 lint:
 	golangci-lint run ./...

--- a/docs/install.md
+++ b/docs/install.md
@@ -32,7 +32,7 @@ The binary lands in `$(go env GOBIN)` (defaults to `$HOME/go/bin`) — make sure
 
 ## Prebuilt release archives
 
-Each tagged release publishes archives for macOS (Intel + Apple Silicon), Linux (amd64 + arm64), and Windows (amd64 + arm64) on the [GitHub releases page](https://github.com/steipete/sonoscli/releases). Download, extract, drop the `sonos` binary somewhere on your `PATH`.
+Each tagged release publishes archives for macOS (universal, plus Intel and Apple Silicon compatibility archives), Linux (amd64 + arm64), and Windows (amd64 + arm64) on the [GitHub releases page](https://github.com/steipete/sonoscli/releases). Download, extract, drop the `sonos` binary somewhere on your `PATH`.
 
 ## From source
 


### PR DESCRIPTION
The code builds (and works) for intel macs as a new universal binary. The docs previously reported that this would work on [intel macs](https://sonoscli.sh/install.html#prebuilt-release-archives) despite it building for ARM only. This fixes that mismatch.

## Verification

Verified local universal build for mac os:

```
 mkdir -p bin
tmp="$(mktemp -d)"; \
        trap 'rm -rf "$tmp"' EXIT; \
        GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -o "$tmp/sonos-darwin-amd64" ./cmd/sonos; \
        GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -o "$tmp/sonos-darwin-arm64" ./cmd/sonos; \
        lipo -create -output bin/sonos-darwin-universal "$tmp/sonos-darwin-amd64" "$tmp/sonos-darwin-arm64"
go: downloading github.com/spf13/cobra v1.10.2
go: downloading github.com/spf13/pflag v1.0.10
> lipo -archs bin/sonos-darwin-universal
x86_64 arm64
```

I also ran GoReleaser to verify locally:

```
$ env GOCACHE=/tmp/sonoscli/.gocache GOMODCACHE=/tmp/sonoscli/.gomodcache goreleaser release --snapshot --clean
  • starting release
  • skipping announce, publish, and validate...
  • cleaning distribution directory
  • loading environment variables
  • getting and validating git state
    • using tags                                     previous=v0.3.0 current=v0.3.1
    • pipe skipped or partially skipped              reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
    • DEPRECATED:  archives.format  should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
    • DEPRECATED:  archives.format_overrides.format  should not be used anymore, check https://goreleaser.com/deprecations#archivesformat_overridesformat for more info
    • DEPRECATED:  archives.builds  should not be used anymore, check https://goreleaser.com/deprecations#archivesbuilds for more info
  • snapshotting
    • building snapshot...                           version=0.3.1-SNAPSHOT-bca9967
  • ensuring distribution directory
  • setting up metadata
  • writing release metadata
  • loading go mod information
  • build prerequisites
  • building binaries
    • building                                       paths=cmd/sonos binaries=sonos target=windows_arm64_v8.0
    • building                                       paths=cmd/sonos binaries=sonos target=darwin_arm64_v8.0
    • building                                       paths=cmd/sonos binaries=sonos target=windows_amd64_v1
    • building                                       paths=cmd/sonos binaries=sonos target=linux_arm64_v8.0
    • building                                       paths=cmd/sonos binaries=sonos target=linux_amd64_v1
    • building                                       paths=cmd/sonos binaries=sonos target=darwin_amd64_v1
  • universal binaries
    • creating from 2 binaries                       id=sonos binary=dist/sonos_darwin_all/sonos
  • archives
    • archiving                                      name=dist/sonoscli_0.3.1-SNAPSHOT-bca9967_windows_arm64.zip
    • archiving                                      name=dist/sonoscli_0.3.1-SNAPSHOT-bca9967_linux_amd64.tar.gz
    • archiving                                      name=dist/sonoscli_0.3.1-SNAPSHOT-bca9967_macos-universal.tar.gz
    • archiving                                      name=dist/sonoscli_0.3.1-SNAPSHOT-bca9967_windows_amd64.zip
    • archiving                                      name=dist/sonoscli_0.3.1-SNAPSHOT-bca9967_linux_arm64.tar.gz
  • calculating checksums
  • writing artifacts metadata
  • you are using deprecated options, check the output above for details
  • release succeeded after 2s
  • thanks for using GoReleaser!

$ tar -tzf dist/sonoscli_0.3.1-SNAPSHOT-bca9967_macos-universal.tar.gz
CHANGELOG.md
LICENSE
README.md
sonos

$ mkdir goreleaser-check

$ tar -xzf dist/sonoscli_0.3.1-SNAPSHOT-bca9967_macos-universal.tar.gz -C goreleaser-check

$ file goreleaser-check/sonos
goreleaser-check/sonos: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64]
goreleaser-check/sonos (for architecture x86_64):       Mach-O 64-bit executable x86_64
goreleaser-check/sonos (for architecture arm64):        Mach-O 64-bit executable arm64

$ lipo -archs goreleaser-check/sonos
arm64 x86_64

$ shasum -a 256 dist/sonoscli_0.3.1-SNAPSHOT-bca9967_macos-universal.tar.gz
2a8dcea73315e7e59aae524993100ecd8dbb9bf1dfa9be8bb385471af1ec9104  dist/sonoscli_0.3.1-SNAPSHOT-bca9967_macos-universal.tar.gz
```

And, this screenshot
<img width="2362" height="1284" alt="CleanShot 2026-06-01 at 18 34 20" src="https://github.com/user-attachments/assets/97909e3b-9e70-46c2-a989-80061e4c127a" />

## After this

Once universal builds are in the release pipeline, the next step will be to update the homebrew [formula](https://github.com/steipete/homebrew-tap) after this change lands to remove this line:

https://github.com/steipete/homebrew-tap/blob/4941d0e59cc67cb886a0a4ab72d5bba34c769c40/Formula/sonoscli.rb#L9

But we can't do that until after a new release here is published.