### PR TITLE
chore(deps): refresh build toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         run: go test -race ./...
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9.2.0
+        uses: golangci/golangci-lint-action@v9.3.0
         with:
-          version: v2.12.1
+          version: v2.12.2
           args: ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
+          go-version: "1.26.x"
           cache: true
 
       - name: Stash GoReleaser config
@@ -37,7 +37,7 @@ jobs:
         run: git checkout ${{ inputs.tag }}
 
       - name: GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7.2.3
         with:
           distribution: goreleaser
           version: latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+### Changed
+- Docker and release builds now use supported Go 1.26 toolchains, with current stable GoReleaser and lint workflow dependencies.
+
 ## [0.3.2] - 2026-06-10
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-ARG GO_VERSION=1.22
+ARG GO_VERSION=1.26
 
 FROM golang:${GO_VERSION}-bookworm AS build
 WORKDIR /src


### PR DESCRIPTION
## Summary

- build Docker and release binaries with the supported Go 1.26 toolchain while retaining Go 1.22 as the source compatibility floor
- update GoReleaser Action to v7.2.3
- update golangci-lint Action to v9.3.0 and golangci-lint to v2.12.2

## Proof

- `make ci` (75.8% overall coverage; 88.3% stream proxy coverage)
- `govulncheck ./...` (no vulnerabilities)
- `actionlint`
- `goreleaser check --config .goreleaser.yaml`
- pulled Docker build with `golang:1.26-bookworm`; image `--version` and `--help`
- exact local Go 1.26.4 binary: `--version`, `--help`, read-only live discovery (7 zones), status, and group status
- autoreview: clean, no accepted/actionable findings
