### PR TITLE
fix(smapi): accept token-only authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+### Fixed
+- SMAPI authentication now accepts services that return an auth token without a refresh key, such as Pocket Casts. Thanks @stateanomaly.
+
 ## [0.3.3] - 2026-07-01
 
 ### Changed

--- a/internal/sonos/smapi.go
+++ b/internal/sonos/smapi.go
@@ -209,8 +209,8 @@ func (c *SMAPIClient) CompleteAuthentication(ctx context.Context, linkCode, link
 		DeviceID:    c.DeviceID,
 		HouseholdID: c.HouseholdID,
 	}
-	if pair.AuthToken == "" || pair.PrivateKey == "" {
-		return SMAPITokenPair{}, errors.New("empty token pair in response")
+	if pair.AuthToken == "" {
+		return SMAPITokenPair{}, errors.New("empty auth token in response")
 	}
 	if err := c.TokenStore.Save(c.Service.ID, c.HouseholdID, pair); err != nil {
 		return SMAPITokenPair{}, err
@@ -593,9 +593,11 @@ func (c *SMAPIClient) buildCredentialsHeader(allowUnauthed bool) (string, error)
 			creds.WriteString(`<token>`)
 			creds.WriteString(xmlEscapeText(pair.AuthToken))
 			creds.WriteString(`</token>`)
-			creds.WriteString(`<key>`)
-			creds.WriteString(xmlEscapeText(pair.PrivateKey))
-			creds.WriteString(`</key>`)
+			if pair.PrivateKey != "" {
+				creds.WriteString(`<key>`)
+				creds.WriteString(xmlEscapeText(pair.PrivateKey))
+				creds.WriteString(`</key>`)
+			}
 			creds.WriteString(`<householdId>`)
 			creds.WriteString(xmlEscapeText(c.HouseholdID))
 			creds.WriteString(`</householdId>`)

--- a/internal/sonos/smapi_more_test.go
+++ b/internal/sonos/smapi_more_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -165,6 +166,86 @@ func TestSMAPIClient_BeginAndCompleteAuthentication_DeviceLink(t *testing.T) {
 	}
 	if _, ok, _ := store.Load(sm.Service.ID, sm.HouseholdID); !ok {
 		t.Fatalf("expected token to be stored")
+	}
+}
+
+func TestSMAPIClient_CompleteAuthentication_AcceptsTokenWithoutPrivateKey(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if action := strings.Trim(r.Header.Get("SOAPACTION"), `"`); action != smapiSOAPAction+"getDeviceAuthToken" {
+			t.Fatalf("unexpected SOAPACTION: %q", action)
+		}
+		_, _ = w.Write([]byte(`<?xml version="1.0"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+  <s:Body>
+    <getDeviceAuthTokenResponse xmlns="http://www.sonos.com/Services/1.1">
+      <getDeviceAuthTokenResult>
+        <authToken> token-only </authToken>
+      </getDeviceAuthTokenResult>
+    </getDeviceAuthTokenResponse>
+  </s:Body>
+</s:Envelope>`))
+	}))
+	t.Cleanup(srv.Close)
+
+	store, err := NewFileSMAPITokenStore(filepath.Join(t.TempDir(), "tokens.json"))
+	if err != nil {
+		t.Fatalf("NewFileSMAPITokenStore: %v", err)
+	}
+	sm := &SMAPIClient{
+		httpClient:  srv.Client(),
+		Service:     MusicServiceDescriptor{ID: "233", Name: "Pocket Casts", SecureURI: srv.URL, Auth: MusicServiceAuthDeviceLink},
+		HouseholdID: "Sonos_TEST",
+		DeviceID:    "RINCON_DEVICEID",
+		TokenStore:  store,
+	}
+
+	pair, err := sm.CompleteAuthentication(context.Background(), "ABCD", "")
+	if err != nil {
+		t.Fatalf("CompleteAuthentication: %v", err)
+	}
+	if pair.AuthToken != "token-only" || pair.PrivateKey != "" {
+		t.Fatalf("unexpected pair: %#v", pair)
+	}
+	stored, ok, err := store.Load(sm.Service.ID, sm.HouseholdID)
+	if err != nil || !ok {
+		t.Fatalf("Load: ok=%v err=%v", ok, err)
+	}
+	if stored.AuthToken != "token-only" || stored.PrivateKey != "" {
+		t.Fatalf("unexpected stored pair: %#v", stored)
+	}
+}
+
+func TestSMAPIClient_CompleteAuthentication_RejectsMissingAuthToken(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`<?xml version="1.0"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+  <s:Body>
+    <getDeviceAuthTokenResponse xmlns="http://www.sonos.com/Services/1.1">
+      <getDeviceAuthTokenResult><privateKey>refresh-key</privateKey></getDeviceAuthTokenResult>
+    </getDeviceAuthTokenResponse>
+  </s:Body>
+</s:Envelope>`))
+	}))
+	t.Cleanup(srv.Close)
+
+	store := &memSMAPITokenStore{}
+	sm := &SMAPIClient{
+		httpClient:  srv.Client(),
+		Service:     MusicServiceDescriptor{ID: "233", SecureURI: srv.URL, Auth: MusicServiceAuthDeviceLink},
+		HouseholdID: "Sonos_TEST",
+		DeviceID:    "RINCON_DEVICEID",
+		TokenStore:  store,
+	}
+
+	if _, err := sm.CompleteAuthentication(context.Background(), "ABCD", ""); err == nil {
+		t.Fatal("expected missing auth token error")
+	}
+	if store.Has(sm.Service.ID, sm.HouseholdID) {
+		t.Fatal("missing auth token must not be stored")
 	}
 }
 

--- a/internal/sonos/smapi_test.go
+++ b/internal/sonos/smapi_test.go
@@ -96,6 +96,52 @@ func TestSMAPI_Search_Success(t *testing.T) {
 	}
 }
 
+func TestSMAPI_Search_TokenWithoutPrivateKey(t *testing.T) {
+	var seenBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := ioReadAllLimit(r.Body, 1<<20)
+		seenBody = string(body)
+		w.Header().Set("Content-Type", `text/xml; charset="utf-8"`)
+		_, _ = w.Write([]byte(`<?xml version="1.0"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+  <s:Body>
+    <searchResponse xmlns="http://www.sonos.com/Services/1.1">
+      <searchResult><index>0</index><count>0</count><total>0</total></searchResult>
+    </searchResponse>
+  </s:Body>
+</s:Envelope>`))
+	}))
+	defer srv.Close()
+
+	store := newMemTokenStore()
+	if err := store.Save("233", "Sonos_ABC", SMAPITokenPair{AuthToken: "TOKEN"}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	c := &SMAPIClient{
+		httpClient: srv.Client(),
+		Service: MusicServiceDescriptor{
+			ID:        "233",
+			Name:      "Pocket Casts",
+			SecureURI: srv.URL,
+			Auth:      MusicServiceAuthDeviceLink,
+		},
+		HouseholdID:     "Sonos_ABC",
+		DeviceID:        "DEV",
+		TokenStore:      store,
+		searchPrefixMap: map[string]string{"shows": "search:show"},
+	}
+
+	if _, err := c.Search(context.Background(), "shows", "test", 0, 10); err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if !strings.Contains(seenBody, "<token>TOKEN</token>") {
+		t.Fatalf("request missing auth token: %s", seenBody)
+	}
+	if strings.Contains(seenBody, "<key>") {
+		t.Fatalf("request unexpectedly included an empty private key: %s", seenBody)
+	}
+}
+
 func TestSMAPI_TokenRefresh(t *testing.T) {
 	var calls int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/sonos/smapi_tokens.go
+++ b/internal/sonos/smapi_tokens.go
@@ -72,8 +72,8 @@ func (s *FileSMAPITokenStore) Save(serviceID, householdID string, pair SMAPIToke
 	}
 	pair.AuthToken = strings.TrimSpace(pair.AuthToken)
 	pair.PrivateKey = strings.TrimSpace(pair.PrivateKey)
-	if pair.AuthToken == "" || pair.PrivateKey == "" {
-		return errors.New("token pair is empty")
+	if pair.AuthToken == "" {
+		return errors.New("auth token is empty")
 	}
 	if pair.UpdatedAt.IsZero() {
 		pair.UpdatedAt = time.Now().UTC()

--- a/internal/sonos/smapi_tokens_test.go
+++ b/internal/sonos/smapi_tokens_test.go
@@ -30,6 +30,16 @@ func TestFileSMAPITokenStore_SaveLoadHas(t *testing.T) {
 	if err := s.Save("svc", "hh", SMAPITokenPair{}); err == nil {
 		t.Fatalf("expected error for empty token pair")
 	}
+	if err := s.Save("svc", "token-only", SMAPITokenPair{AuthToken: "a"}); err != nil {
+		t.Fatalf("Save token-only: %v", err)
+	}
+	tokenOnly, ok, err := s.Load("svc", "token-only")
+	if err != nil || !ok {
+		t.Fatalf("Load token-only: ok=%v err=%v", ok, err)
+	}
+	if tokenOnly.AuthToken != "a" || tokenOnly.PrivateKey != "" {
+		t.Fatalf("unexpected token-only pair: %#v", tokenOnly)
+	}
 
 	now := time.Date(2025, 12, 13, 0, 0, 0, 0, time.UTC)
 	if err := s.Save("svc", "hh", SMAPITokenPair{AuthToken: "a", PrivateKey: "b", UpdatedAt: now}); err != nil {


### PR DESCRIPTION
## Summary

- accept SMAPI authentication responses with an auth token but no private refresh key
- persist token-only credentials and omit the optional empty key from later SOAP headers
- keep empty auth-token responses invalid
- add completion, persistence, and authenticated-request regression coverage

Fixes #20

## Proof

- `make ci` — total coverage 75.7%, stream proxy coverage 87.2%, lint 0 issues, race tests and vet passed
- focused regression tests cover token-only completion, file persistence, token-plus-key behavior, and missing-token rejection
- real built `sonos` binary completed token-only auth against a local SMAPI fixture, persisted the credential, and performed a separate-process authenticated search; the fixture confirmed the token was sent and no empty `<key>` element was emitted
- source-blind behavior validation passed valid completion, persisted reuse, and missing-token rejection
- AutoReview: clean, no accepted/actionable findings

The live fixture follows Sonos's documented valid `getDeviceAuthToken` response shape where `privateKey` is omitted: https://docs.sonos.com/docs/getdeviceauthtoken
