### PR TITLE
chore(deps): require Go 1.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.22.x"
+          go-version: "1.26.x"
           cache: true
 
       - name: Format check (gofmt)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 ### Fixed
 - SMAPI authentication now accepts services that return an auth token without a refresh key, such as Pocket Casts. Thanks @stateanomaly.
 
+### Changed
+- Development, CI, and source installs now use the supported Go 1.26 toolchain.
+
 ## [0.3.3] - 2026-07-01
 
 ### Changed

--- a/docs/install.md
+++ b/docs/install.md
@@ -21,7 +21,7 @@ brew upgrade steipete/tap/sonoscli
 
 ## go install
 
-If you already have a Go toolchain (Go 1.22+):
+If you already have a Go toolchain (Go 1.26+):
 
 ```bash
 go install github.com/steipete/sonoscli/cmd/sonos@latest

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -8,7 +8,7 @@ Goals:
 
 ## Prereqs
 
-- Go `1.22+`
+- Go `1.26+`
 - `golangci-lint` installed (for `make lint` / `pnpm lint`)
 - `ffmpeg` and `yt-dlp` installed for `play-url` checks
 - Sonos speakers reachable on the local network (UDP SSDP + TCP 1400)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/steipete/sonoscli
 
-go 1.22
+go 1.26
 
 require github.com/spf13/cobra v1.10.2
 

--- a/internal/cli/play_url_playlist_test.go
+++ b/internal/cli/play_url_playlist_test.go
@@ -3,8 +3,6 @@ package cli
 import (
 	"context"
 	"errors"
-	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -252,11 +250,8 @@ func TestLooksLikePlaylistURLDoesNotAutoDetectYoutuBeVideoLinks(t *testing.T) {
 func TestEnumerateYTDLPPlaylistReturnsErrorWhenYTDLPFails(t *testing.T) {
 	t.Parallel()
 
-	path := filepath.Join(t.TempDir(), "yt-dlp")
 	script := "#!/bin/sh\necho 'ERROR: invalid url' 1>&2\nexit 1\n"
-	if err := os.WriteFile(path, []byte(script), 0o700); err != nil {
-		t.Fatalf("write fake: %v", err)
-	}
+	path := writeTestExecutable(t, "yt-dlp", script)
 
 	_, err := enumerateYTDLPPlaylist(context.Background(), path, "https://example.com/x", 0)
 	if err == nil {
@@ -267,10 +262,6 @@ func TestEnumerateYTDLPPlaylistReturnsErrorWhenYTDLPFails(t *testing.T) {
 func writeFakeYTDLPPlaylist(t *testing.T, output string) string {
 	t.Helper()
 
-	path := filepath.Join(t.TempDir(), "yt-dlp")
 	script := "#!/bin/sh\ncat <<'EOF'\n" + output + "EOF\n"
-	if err := os.WriteFile(path, []byte(script), 0o700); err != nil {
-		t.Fatalf("write fake yt-dlp: %v", err)
-	}
-	return path
+	return writeTestExecutable(t, "yt-dlp", script)
 }

--- a/internal/cli/play_youtube_test.go
+++ b/internal/cli/play_youtube_test.go
@@ -3,8 +3,6 @@ package cli
 import (
 	"context"
 	"errors"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -168,7 +166,6 @@ func TestParseYTDLPStream(t *testing.T) {
 func TestYTDLPResolverResolve(t *testing.T) {
 	t.Parallel()
 
-	path := filepath.Join(t.TempDir(), "yt-dlp")
 	script := `#!/bin/sh
 if [ "${1:-}" = "fail" ]; then
   echo nope >&2
@@ -178,9 +175,7 @@ cat <<'JSON'
 {"title":"Video Title","url":"https://rr.example/audio.m4a","webpage_url":"https://www.youtube.com/watch?v=abc","format_id":"140","ext":"m4a","acodec":"mp4a.40.2"}
 JSON
 `
-	if err := os.WriteFile(path, []byte(script), 0o700); err != nil {
-		t.Fatalf("write fake yt-dlp: %v", err)
-	}
+	path := writeTestExecutable(t, "yt-dlp", script)
 
 	stream, err := (ytDLPResolver{path: path}).Resolve(context.Background(), "https://www.youtube.com/watch?v=abc", youtubeResolveOptions{})
 	if err != nil {

--- a/internal/cli/test_script_test.go
+++ b/internal/cli/test_script_test.go
@@ -1,0 +1,20 @@
+package cli
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeTestExecutable(t *testing.T, name, contents string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), name)
+	cmd := exec.Command("/bin/sh", "-c", `umask 077; cat > "$1"; chmod 700 "$1"`, "write-test-executable", path)
+	cmd.Stdin = strings.NewReader(contents)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("write test executable: %v: %s", err, strings.TrimSpace(string(output)))
+	}
+	return path
+}


### PR DESCRIPTION
## Summary

- raise the source, development, and CI Go floor from 1.22 to 1.26
- align CI and source-install docs with the existing Go 1.26 Docker and release toolchains
- document the supported-toolchain change in Unreleased
- avoid Linux `ETXTBSY` flakes when parallel tests create fake `yt-dlp` executables

Go 1.22 is outside Go's two-major-release support window. Go 1.26.5 is the current stable patch release and includes security fixes: https://go.dev/doc/devel/release

## Proof

- `go mod tidy -diff` — clean
- `go run golang.org/x/vuln/cmd/govulncheck@latest ./...` — no vulnerabilities found
- `make ci` — total coverage 75.6%, stream proxy coverage 87.2%, lint 0 issues, race tests and vet passed
- `make docs-site` — built successfully
- built native plus darwin/linux/windows amd64/arm64 targets
- exact-head native binary reported Go 1.26.5, revision `718881113045f265fcfed4d37784ac87939fd664`, and `vcs.modified=false`
- real binary `--version`, `--help`, and `discover --timeout 2s --format json` passed; discovery returned a valid empty array on the current network
- reproduced the fake-executable race in a Go 1.26 Linux container (6 failures in 100 runs), then passed 100/100 focused runs locally and 100/100 in Linux after moving executable writes into a child process
- AutoReview: clean, no accepted/actionable findings
