### PR TITLE
chore(deps): refresh release dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v7
         with:
           go-version: "1.26.x"
           cache: true

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: "1.26.x"
           cache: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /out/sonos ./cmd/sonos
 
-FROM python:3.12-slim
+FROM python:3.14-slim
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates curl ffmpeg tzdata \
     && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
## Summary

- update actions/setup-go from v6 to v7 in CI and release workflows
- update the pinned actions/setup-node release from v6.4.0 to v7.0.0
- update the Docker runtime from Python 3.12 to Python 3.14

## Proof

- `go mod tidy -diff`
- `go run golang.org/x/vuln/cmd/govulncheck@latest ./...`
- `make ci`
- `make build`
- `make docs-site`
- `docker build --pull -t sonoscli:release-deps .`
- container smoke tests for `sonos --version`, `sonos --help`, Python, ffmpeg, yt-dlp, and curl
- AutoReview clean
