### PR TITLE
chore(release): prepare 0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,20 @@
 
 ## [Unreleased]
 
-### Added
+## [0.3.4] - 2026-07-17
+
+### Highlights
+- Pocket Casts and other SMAPI services that return token-only credentials can now finish authentication and stay signed in.
+- Source builds, CI, releases, and Docker now use current supported Go, Python, and GitHub Actions toolchains.
 
 ### Fixed
-- SMAPI authentication now accepts services that return an auth token without a refresh key, such as Pocket Casts. Thanks @stateanomaly.
+- SMAPI authentication now accepts a valid auth token without an optional refresh key while still rejecting empty auth tokens. Thanks @stateanomaly.
+- Parallel CLI tests no longer intermittently fail with Linux `ETXTBSY` errors when creating fake `yt-dlp` executables.
 
 ### Changed
-- Development, CI, and source installs now use the supported Go 1.26 toolchain.
+- Development, CI, and source installs now require Go 1.26.
+- Docker images now use Python 3.14; CI, docs, and release workflows use the latest stable setup actions.
+- Release automation now checks Homebrew tap completion at a lower request rate.
 
 ## [0.3.3] - 2026-07-01
 

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -2,4 +2,4 @@ package cli
 
 // Version is the CLI version reported by `sonos --version`.
 // Keep in sync with CHANGELOG.md.
-const Version = "0.3.3"
+const Version = "0.3.4"


### PR DESCRIPTION
## Summary

- rewrite the 0.3.4 changelog from every commit since v0.3.3
- add highlights and grouped full entries while preserving the @stateanomaly thanks
- bump the CLI version to 0.3.4

This prepares the release only. It does not tag, publish, or create a GitHub release.

## Proof

- `go mod tidy -diff`
- `go run golang.org/x/vuln/cmd/govulncheck@latest ./...`
- `make ci`
- `make build`
- native `sonos --version`, `sonos --help`, and discovery smoke test
- `make build-darwin` and universal binary inspection
- `make docs-site`
- `actionlint`
- pulled-base Docker build and CLI smoke test
- GoReleaser v2.17.0 config validation and snapshot build for all configured targets
- all seven snapshot archive checksums verified
- universal snapshot binary reports `sonos 0.3.4`
- AutoReview clean
