### PR TITLE
ci: migrate releases to unified pipeline

### DIFF
--- a/.github/workflows/release-legacy.yml
+++ b/.github/workflows/release-legacy.yml
@@ -1,13 +1,12 @@
-name: release
+# Legacy publishing fallback retained by migration policy. Tags do not trigger it.
+# This path bypasses unified signing and notarization; use only with explicit approval.
+name: Release (legacy manual fallback)
 
 on:
-  push:
-    tags:
-      - "v*"
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to (re)release (e.g. v0.1.0)"
+        description: "Existing tag to release (for example, v0.3.4)"
         required: true
         type: string
 
@@ -33,7 +32,6 @@ jobs:
         run: cp .goreleaser.yaml /tmp/.goreleaser.yaml
 
       - name: Checkout release tag
-        if: ${{ github.event_name == 'workflow_dispatch' }}
         run: git checkout ${{ inputs.tag }}
 
       - name: GoReleaser
@@ -51,11 +49,7 @@ jobs:
     steps:
       - name: Resolve release metadata
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            release_tag="${{ inputs.tag }}"
-          else
-            release_tag="${{ github.ref_name }}"
-          fi
+          release_tag="${{ inputs.tag }}"
           release_version="${release_tag#v}"
           {
             echo "RELEASE_TAG=${release_tag}"

--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -1,0 +1,33 @@
+name: Release (unified)
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (for example, 0.3.5)"
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  release:
+    permissions:
+      actions: read
+      checks: read
+      contents: write
+      pull-requests: write
+      statuses: read
+    uses: openclaw/release-workflows/.github/workflows/release-go-cli.yml@v1.0.0-alpha.12
+    with:
+      version: ${{ inputs.version }}
+      repository-type: personal
+      homebrew-tap: steipete/homebrew-tap
+      homebrew-formula: sonoscli
+    secrets:
+      MACOS_SIGNING_P12: ${{ secrets.MACOS_SIGNING_P12 }}
+      MACOS_SIGNING_P12_PASSWORD: ${{ secrets.MACOS_SIGNING_P12_PASSWORD }}
+      ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+      ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+      ASC_PRIVATE_KEY_P8: ${{ secrets.ASC_PRIVATE_KEY_P8 }}
+      TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}


### PR DESCRIPTION
## Summary

- call the unified Go CLI release workflow at `v1.0.0-alpha.12`
- route Homebrew handoff explicitly to `steipete/homebrew-tap`
- retire tag-triggered legacy publishing while retaining the documented manual fallback

## Verification

- `actionlint .github/workflows/release-unified.yml .github/workflows/release-legacy.yml`
- `go test ./...`
- AutoReview: clean

No release dispatch in this PR.
